### PR TITLE
Debian/functions.sh: set up cassandane.ini earlier

### DIFF
--- a/Debian/functions.sh
+++ b/Debian/functions.sh
@@ -98,6 +98,8 @@ function _cassandane {
     git checkout ${CASSANDANEBRANCH:-"origin/master"}
     git clean -f -x -d
 
+    cp -af cassandane.ini.dockertests cassandane.ini
+
     retval=$(_shell make)
 
     if [ ${retval} -ne 0 ]; then
@@ -105,8 +107,6 @@ function _cassandane {
         popd >&3
         return ${retval}
     fi
-
-    cp -af cassandane.ini.dockertests cassandane.ini
 
     retval=$(_shell ./testrunner.pl -f pretty -j 4 ${CASSANDANEOPTS})
 


### PR DESCRIPTION
Part of `make` expects to be able to read cassandane.ini to find
the Cyrus perl modules, in order to properly syntax check annotator.pl.
So set it up before running make.

We got away with this in the past because the paths happened to
be the same as the defaults that would be assumed if cassandane.ini
was missing, but cassandane.ini not being found is now an error
(as of https://github.com/cyrusimap/cassandane/commit/53a584c580345643187b3e6cc9a7640121a4a2a2).