### PR TITLE
functions.sh: don't --enable-maintainer-mode

### DIFF
--- a/Debian/functions.sh
+++ b/Debian/functions.sh
@@ -58,7 +58,6 @@ function _cyrusbuild {
         --enable-gssapi
         --enable-http
         --enable-idled
-        --enable-maintainer-mode
         --enable-murder
         --enable-nntp
         --enable-replication


### PR DESCRIPTION
maintainer mode is for building release tarballs, not ordinary installs