### PR TITLE
run cassandane as not-root, +1

### DIFF
--- a/Debian/functions.sh
+++ b/Debian/functions.sh
@@ -17,16 +17,13 @@ function _cyrusclone {
 function _cyrusbuild {
     pushd /srv/cyrus-imapd.git >&3
 
-    if [ "$TRAVIS_PULL_REQUEST" = "false" ];
+    if [ -z "$TRAVIS_PULL_REQUEST" -o "$TRAVIS_PULL_REQUEST" = "false" ];
     then
         # Not a pull request
-        CYRUSBRANCH=$TRAVIS_BRANCH
+        CYRUSBRANCH=${TRAVIS_BRANCH:-"origin/master"}
         export CYRUSBRANCH
         git fetch
-    fi
-
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ];
-    then
+    else
         # A pull request
         CYRUSBRANCH="PR_TEST_BRANCH"
         export CYRUSBRANCH
@@ -35,7 +32,7 @@ function _cyrusbuild {
 
     echo "===> Pulling branch $CYRUSBRANCH..."
 
-    git checkout ${CYRUSBRANCH:-"origin/master"}
+    git checkout $CYRUSBRANCH
     git clean -f -x -d
 
     CFLAGS="-g -W -Wall -Wextra -Werror"


### PR DESCRIPTION
Two things here:

* Start Cassandane as cyrus:mail rather than as root.  This fixes the spew of Test2::IPC permission failure errors at the end of the run.  Cassandane switches user to cyrus itself anyway, but Test2::IPC creates its temp files during BEGIN, before it switches user, and if was started as root then they were created in a way that they can't be used or removed later as the cyrus user, thus the errors from the destructors.
* Tighten up the handling of `$TRAVIS...` environment variables, to make things a little nicer when running directly in docker.

Please review the second one in particular very closely.  It works fine directly in docker, but we have no way of testing that it still works under travis until we push it, and pushing it is expensive.  I think it's correct, but everyone thinks their code is correct until it turns out it's not... 😅