### PR TITLE
Debian/Dockerfile: update from buster to bullseye

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 MAINTAINER Cyrus IMAP <docker@role.fastmailteam.com>
 
 # RUN echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until
@@ -85,12 +85,11 @@ RUN apt-get update && apt-get -y install \
     php-curl \
     pkg-config \
     po-debconf \
-    python-docutils \
-    python-sphinx \
     rsync \
     rsyslog \
     sudo \
     sphinx-common \
+    sphinx-doc \
     tcl-dev \
     transfig \
     uuid-dev \
@@ -221,7 +220,7 @@ RUN mkdir /tmp/cass
 RUN chown cyrus /tmp/cass
 
 WORKDIR /root
-ENV IMAGE buster
+ENV IMAGE bullseye
 ADD https://raw.githubusercontent.com/cyrusimap/cyrus-docker/master/Debian/dot.bashrc /root/.bashrc
 
 WORKDIR /


### PR DESCRIPTION
We had [disabled a few Cassandane tests](https://github.com/cyrusimap/cyrus-imapd/commit/4f8beba590752263bf0355fcc98022858bed3116) in cyrus-imapd because the Docker image we used to run the tests in GitHub actions was older than what we actually use to run Cyrus at Fastmail.

I'm no Docker expert, but this seemed pretty straightforward to update.  I've published an [image built from this](https://hub.docker.com/r/cyrusimapdocker/cyrus-bullseye) to Docker hub and [made a PR against cyrus-imapd to use this image](https://github.com/cyrusimap/cyrus-imapd/pull/4307).

I'll try to make a note here if it fails/succeeds.