### PR TITLE
make cyrus-docker capable of building the docs

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -151,6 +151,7 @@ apt-get -y install --no-install-recommends \
     libthrowable-perl \
     libwww-perl \
     `# BEGIN for building docs` \
+    libpod-pom-view-restructured-perl \
     python3-git \
     python3-sphinx \
     python3-sphinx-rtd-theme \

--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -150,6 +150,11 @@ apt-get -y install --no-install-recommends \
     libtest-routine-perl \
     libthrowable-perl \
     libwww-perl \
+    `# BEGIN for building docs` \
+    python3-git \
+    python3-sphinx \
+    python3-sphinx-rtd-theme \
+    rsync \
     `# BEGIN for cyrus-docker or just quality of life` \
     less \
     tini

--- a/Debian/bin/lib/Cyrus/Docker/Command/makedocs.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/makedocs.pm
@@ -1,0 +1,18 @@
+use v5.36.0;
+
+package Cyrus::Docker::Command::makedocs;
+use Cyrus::Docker -command;
+
+use Process::Status;
+
+sub abstract { 'make the docs site using Sphinx' }
+
+sub execute ($self, $opt, $args) {
+  my $root = "/srv/cyrus-imapd/docsrc";
+  chdir $root or die "can't chdir to $root: $!";
+
+  system('make', 'html');
+  Process::Status->assert_ok('making "html" target');
+}
+
+1;


### PR DESCRIPTION
With this branch, `dar makedocs` will make the HTML version of the docs.  Since these will be built into your repo, you can open them in your browser as files or by running a trivial web server like `python3 -m http.server`.

We have talked about making the container self-contain all ephemeral files, in which case we may want to change this in the future, either providing a second mount for doc output, or putting a small web server into the container.  Because "just doing that" now would require finding a way to manage ports between multiple containers, I'm punting.  This is a minor convenience and if it has more value we can give it more work later.