### PR TITLE
cyd test: add some options to pass through to testrunner

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker/Command/makedocs.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/makedocs.pm
@@ -11,7 +11,12 @@ sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root->child('docsrc');
   chdir $root or die "can't chdir to $root: $!";
 
-  system('make', 'html');
+  # I would prefer to use long form options, but they are not added until
+  # Sphinx v7, and we are using v5 right now. -- rjbs, 2025-01-10
+  #
+  # -n is "--nitpicky"
+  # -W is "--fail-on-warning"
+  system('make', q{SPHINXOPTS=-n -W}, 'html');
   Process::Status->assert_ok('making "html" target');
 }
 

--- a/Debian/bin/lib/Cyrus/Docker/Command/test.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/test.pm
@@ -10,7 +10,7 @@ sub opt_spec {
   return (
     [ 'format=s', "which formatter to use; default: prettier",
                   { default => 'prettier' } ],
-    [ 'slow',     "run slow tests" ],
+    [ 'slow!',    "run slow tests", { default => 1 } ],
     [ 'rerun',    "only run previously-failed tests" ],
   );
 }


### PR DESCRIPTION
This is so that the GitHub Actions for testing cyrus-imapd can use `cyd test` to try to avoid reimplementation of behavior.

This also makes warnings fatal, so we can avoid new warnings.