### PR TITLE
Dockerfile: do not init git submodules

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -258,8 +258,6 @@ git clone --depth 1 --shallow-submodules -b $CYRUSLIBS_BRANCH \
   https://github.com/cyrusimap/cyruslibs.git
 cd cyruslibs
 # RUN git checkout origin/master
-git submodule init
-git submodule update
 ./build.sh
 cd ..
 $CLEANUP && rm -rf cyruslibs || true


### PR DESCRIPTION
The cyruslibs build.sh script takes care of this.