### PR TITLE
Debian/Dockerfile: Install tools needed for clang+asan/ubsan

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -19,6 +19,7 @@ apt-get -y install --no-install-recommends \
     bison \
     build-essential \
     check \
+    clang \
     cmake \
     comerr-dev \
     cpanminus \
@@ -37,6 +38,7 @@ apt-get -y install --no-install-recommends \
     libanyevent-perl \
     libbsd-dev \
     libbsd-resource-perl \
+    libclang-rt-dev \
     libcld2-dev \
     libclone-perl \
     libconfig-inifiles-perl \
@@ -85,6 +87,7 @@ apt-get -y install --no-install-recommends \
     libwww-perl \
     libxapian-dev \
     libzephyr-dev \
+    llvm \
     lsb-base \
     net-tools \
     perl \


### PR DESCRIPTION
This way, cyrus-imapd CI builds can make use of clang without having to install it and slow down the builds.