### PR TITLE
Debian/Dockerfile: Install valgrind for CI use

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -141,6 +141,7 @@ apt-get -y install --no-install-recommends \
     python3-sphinx \
     python3-sphinx-rtd-theme \
     rsync \
+    valgrind \
     `# BEGIN for cyrus-docker or just quality of life` \
     less \
     tini


### PR DESCRIPTION
This way we can have `make VG=1 check` CI runs and detect leaks early