### PR TITLE
two minor improvements for cyd (esp. for CI)

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/build.pm
@@ -69,6 +69,8 @@ sub execute ($self, $opt, $args) {
     } elsif ($opt->sanitizer =~ /\Aubsan(_trap)?\z/) {
       $ENV{CYRUS_SAN_FLAGS} = '-fsanitize=undefined';
 
+      $ENV{UBSAN_OPTIONS} = "print_stacktrace=1:halt_on_error=1";
+
       if ($opt->sanitizer eq 'ubsan_trap') {
         $ENV{CYRUS_SAN_FLAGS} .= ' -fsanitize-undefined-trap-on-error';
       }


### PR DESCRIPTION
1. `cyd` will now set `UBSAN_OPTIONS` when building with the --ubsan option(s)
2. `cyd build` now has the complete build process, rather than using the cyrus `build-with-cyruslibs`