### PR TITLE
cyd: syntax check less often, make -j configurable

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker.pm
+++ b/Debian/bin/lib/Cyrus/Docker.pm
@@ -18,8 +18,13 @@ sub repo_root ($self) {
 sub config ($self) {
   $self->{config} //= do {
     my $path = Path::Tiny::path('/etc/cyrus-docker.json');
-    $path->exists ? JSON::XS::decode_json($path->slurp)
-                  : {}
+    my $config = $path->exists ? JSON::XS::decode_json($path->slurp) : {};
+
+    if (defined $config->{default_jobs} && $config->{default_jobs} !~ /\A[0-9]+\z/) {
+      die "$path has a default_jobs option but it isn't an integer\n";
+    }
+
+    $config;
   };
 }
 

--- a/Debian/bin/lib/Cyrus/Docker.pm
+++ b/Debian/bin/lib/Cyrus/Docker.pm
@@ -1,7 +1,8 @@
 package Cyrus::Docker;
 use v5.36.0;
 
-use Path::Tiny;
+use JSON::XS ();
+use Path::Tiny ();
 
 use App::Cmd::Setup 0.336 -app => {
   getopt_conf => [],
@@ -10,7 +11,15 @@ use App::Cmd::Setup 0.336 -app => {
 sub repo_root ($self) {
   $self->{root} //= do {
     my $path = $ENV{CYRUS_CLONE_ROOT} || '/srv/cyrus-imapd';
-    path($path);
+    Path::Tiny::path($path);
+  };
+}
+
+sub config ($self) {
+  $self->{config} //= do {
+    my $path = Path::Tiny::path('/etc/cyrus-docker.json');
+    $path->exists ? JSON::XS::decode_json($path->slurp)
+                  : {}
   };
 }
 

--- a/Debian/bin/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/build.pm
@@ -41,7 +41,7 @@ sub execute ($self, $opt, $args) {
 
   $self->configure($opt) unless $opt->recompile;
 
-  my @jobs = ("-j", $opt->jobs);
+  my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
 
   run(qw( make lex-fix                  ), @jobs);
   run(qw( make                          ), @jobs);

--- a/bin/dar
+++ b/bin/dar
@@ -265,6 +265,24 @@ END
 
   Process::Status->assert_ok("❌ Fixing git permissions in container");
 
+  my $config_file = path('~/.cyrus-docker/config');
+  if (-e $config_file) {
+    run(
+      [
+        'docker', 'cp', '--quiet',
+        $config_file->absolute,
+        "$container_id:/etc/cyrus-docker.json",
+      ],
+      _emptyref(),
+      _emptyref(),
+    );
+
+    if ($?) {
+      warn "❗️ Couldn't copy config into container, " .
+        Process::Status->new($?)->as_string;
+    }
+  }
+
   return $class->_existing_container;
 }
 


### PR DESCRIPTION
1. `cyd test` now has a heuristic about whether to `make syntax` (only useful if https://github.com/cyrusimap/cyrus-imapd/pull/5367 is applied)
2. `cyd` now looks in /etc/cyrus-docker.json for config, which can configure default value for `-j`
3. `dar` will copy ~/.cyrus-docker/config into the container at start