### PR TITLE
cyd build: add -Wformat=2 to builds

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/build.pm
@@ -150,7 +150,7 @@ sub configure ($self, $opt) {
 
   local $ENV{LDFLAGS} = "-L$libsdir/lib/x86_64-linux-gnu -L$libsdir/lib -Wl,-rpath,$libsdir/lib/x86_64-linux-gnu -Wl,-rpath,$libsdir/lib";
   local $ENV{PKG_CONFIG_PATH} = "$libsdir/lib/x86_64-linux-gnu/pkgconfig:$libsdir/lib/pkgconfig:\$PKG_CONFIG_PATH";
-  local $ENV{CFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings $more_cflags";
+  local $ENV{CFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings -Wformat=2 $more_cflags";
   local $ENV{CXXFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror $more_cxxflags";
   local $ENV{PATH} = "$libsdir/bin:$ENV{PATH}";
 


### PR DESCRIPTION
(Only CFLAGS not CXXFLAGS.)