### PR TITLE
Replace term Docker image with OCI image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image
+name: Create and publish an OCI image
 
 on:
   push:
@@ -48,7 +48,7 @@ jobs:
             type=raw,value=bookworm-dev${{ matrix.platform }},enable=${{ github.ref == format('refs/heads/{0}', 'dev') }}
             type=raw,value=bookworm${{ matrix.platform }},enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
 
-      - name: Build and push Docker image
+      - name: Build and push OCI image
         id: push
         uses: docker/build-push-action@v6
         with:

--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -222,7 +222,7 @@ RUN <<EOF
 # This one is weird.  We want a specific commit, just for the sake of pinning
 # to known-good.  We install so that imaptest (below) can rely on the installed
 # Dovecot even after we remove the source.  We remove the source because it's a
-# whole lot of bytes that we don't really need to ship in the Docker image.
+# whole lot of bytes that we don't really need to ship in the OCI image.
 set -e
 mkdir dovecot
 cd dovecot

--- a/Debian/bin/lib/Cyrus/Docker/Command/idle.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/idle.pm
@@ -10,7 +10,7 @@ sub abstract { 'sleep forever, to keep a container running' }
 
 sub execute ($self, $opt, $args) {
   my $motd = <<~'END';
-            /////  |||| Cyrus IMAP docker image
+            /////  |||| Cyrus IMAP OCI image
           /////    |||| IDLE mode (not to be confused with IMAP IDLE)
         /////      ||||
       /////        |||| If you're seeing this, that's weird.

--- a/Debian/bin/lib/Cyrus/Docker/Command/shell.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/shell.pm
@@ -16,7 +16,7 @@ sub command_names ($self, @rest) {
 
 sub do_motd {
   my $menu = <<~'END';
-            /////  |||| Cyrus IMAP docker image
+            /////  |||| Cyrus IMAP OCI image
           /////    |||| Run cyrus-docker (or "cyd") as:
         /////      ||||
       /////        ||||  • cyd clone  - clone cyrus-imapd.git from GitHub

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Docker Images for Cyrus IMAP
+# OCI Images for Cyrus IMAP
 
 This repo contains a Dockerfile for building a container that has all the
 required libraries for building and testing Cyrus IMAP.  It is meant for use in
 Cyrus IMAP's automated test runs, and for testing changes while developing
 Cyrus.
 
-There are two ways to acquire the Docker images.
+There are two ways to acquire the OCI images.
 
 ## Build locally from a Dockerfile
 
@@ -14,7 +14,7 @@ specific to Debian distributions.  While we'd like to support multiple
 platforms in the future, we do not currently do so.
 
 The `Dockerfile` is in the `Debian` directory. To build the Debian
-based Docker image, run the following commands from the current
+based OCI image, run the following commands from the current
 directory:
 
 ```
@@ -22,7 +22,7 @@ $ cd Debian
 $ docker build -t <image-name> .
 ```
 
-where `<image-name>` could be anything you like. Because the current Docker
+where `<image-name>` could be anything you like. Because the current OCI
 image is based on [Debian
 "bookworm"](https://www.debian.org/releases/bookworm/), we would typically run
 it as:

--- a/bin/dar
+++ b/bin/dar
@@ -56,7 +56,7 @@ my $MENU = <<'END';
 dar: the cyrus-docker dev tool
 
 Run "dar COMMAND".  Here are some commands:
- • pull     - pull the latest docker container image
+ • pull     - pull the latest OCI container image
  • start    - start a container to build in the current dir
  • prune    - stop and destroy the container for this dir
  • help     - get more information about how to use dar

--- a/fatpacked/dar
+++ b/fatpacked/dar
@@ -11874,7 +11874,7 @@ my $MENU = <<'END';
 dar: the cyrus-docker dev tool
 
 Run "dar COMMAND".  Here are some commands:
- • pull     - pull the latest docker container image
+ • pull     - pull the latest OCI container image
  • start    - start a container to build in the current dir
  • prune    - stop and destroy the container for this dir
  • help     - get more information about how to use dar


### PR DESCRIPTION
The format, invented by Docker, is now standardized and can be used by different software.  Most notably `podman` can be used as substitution for the `docker` command.  The specification for the data format is at https://github.com/opencontainers/image-spec and is called OCI Image.  Changing the terminology indicates, that the result is in not exclusive for the Docker products.