### PR TITLE
cyd: put (most) build artifacts in /usr/cyrus/build

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker.pm
+++ b/Debian/bin/lib/Cyrus/Docker.pm
@@ -15,6 +15,13 @@ sub repo_root ($self) {
   };
 }
 
+sub build_dir ($self) {
+  $self->{build_dir} //= do {
+    my $path = '/usr/cyrus/build';
+    Path::Tiny::path($path)->mkdir;
+  };
+}
+
 sub config ($self) {
   $self->{config} //= do {
     my $path = Path::Tiny::path('/etc/cyrus-docker.json');


### PR DESCRIPTION
This switches cyd to using a "VPATH" style build, which, in theory, allows compiling from a read-only source tree.

In practice, this isn't quite true.  It would be if we were building from a distribution tarball, where the configure script and everything related to it were already generated.  But we build from a git repository, where that stuff isn't pre-generated, and when it is generated, it ends up in the source directory.
    
But the VPATH build still significantly reduces pollution in the source tree when building with cyd, which is a nice improvement.  It also means cyrus-imapd CI will regularly exercise VPATH builds, which is not as good as running `make distcheck`, but it's part of the way there.