### PR TITLE
dar: after prune, wait for autoremoval to complete

### DIFF
--- a/bin/dar
+++ b/bin/dar
@@ -33,6 +33,7 @@ use Digest::SHA qw(sha1_hex);
 use Getopt::Long ();
 use JSON::PP;
 use Term::ANSIColor qw(colored);
+use Time::HiRes ();
 
 # CPAN
 use IPC::Run qw(run);
@@ -331,9 +332,14 @@ sub do_prune ($class, $args) {
 
   Process::Status->assert_ok("❌ Stopping existing container");
 
-  say "✅ Container stopped.";
-
-  unless ($autoremove) {
+  if ($autoremove) {
+    say "✅ Container stopped, now waiting for removal...";
+    while (1) {
+      run([ qw(docker inspect), $container->{ID} ], _emptyref(), _emptyref(), _emptyref());
+      last if $? != 0;
+      Time::HiRes::sleep(0.25);
+    }
+  } else {
     run([ qw( docker container rm ), $container->{ID} ]);
     Process::Status->assert_ok("❌ Removing stopped container");
   }

--- a/fatpacked/dar
+++ b/fatpacked/dar
@@ -11851,6 +11851,7 @@ use Digest::SHA qw(sha1_hex);
 use Getopt::Long ();
 use JSON::PP;
 use Term::ANSIColor qw(colored);
+use Time::HiRes ();
 
 # CPAN
 use IPC::Run qw(run);
@@ -12149,9 +12150,14 @@ sub do_prune ($class, $args) {
 
   Process::Status->assert_ok("❌ Stopping existing container");
 
-  say "✅ Container stopped.";
-
-  unless ($autoremove) {
+  if ($autoremove) {
+    say "✅ Container stopped, now waiting for removal...";
+    while (1) {
+      run([ qw(docker inspect), $container->{ID} ], _emptyref(), _emptyref(), _emptyref());
+      last if $? != 0;
+      Time::HiRes::sleep(0.25);
+    }
+  } else {
     run([ qw( docker container rm ), $container->{ID} ]);
     Process::Status->assert_ok("❌ Removing stopped container");
   }


### PR DESCRIPTION
By default, dar will create containers that are autoremove, meaning that when stopped, they implicitly rm themselves.  This removal is done in the background, so that the `stop` finishes immediately, but the `rm` is still happening.  Often this is very fast.  Sometimes, it isn't.

That's a problem, because `dar prune && dar start` will crash when `start` finds that the old container is still running, using the same name that we want to reuse.

Let's wait, instead.  We'll just run `docker inspect` over and over until it fails -- and we'll assume, *probably* safely, that it's failing because there is no longer a container with the given id.