### PR TITLE
cyd build: split up into configure, build, check, install

### DIFF
--- a/Debian/bin/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/build.pm
@@ -16,7 +16,7 @@ sub abstract { 'build a configured cyrus-imapd' }
 
 sub opt_spec {
   return (
-    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
+    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make',
                      { default => 8 },
     ],
   );

--- a/Debian/bin/lib/Cyrus/Docker/Command/check.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/check.pm
@@ -1,6 +1,6 @@
 use v5.36.0;
 
-package Cyrus::Docker::Command::build;
+package Cyrus::Docker::Command::check;
 use Cyrus::Docker -command;
 
 use Process::Status;
@@ -12,11 +12,11 @@ my sub run (@args) {
   Process::Status->assert_ok($args[0]);
 }
 
-sub abstract { 'build a configured cyrus-imapd' }
+sub abstract { 'check (make check, cunit) a built cyrus-imapd' }
 
 sub opt_spec {
   return (
-    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
+    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make',
                      { default => 8 },
     ],
   );
@@ -26,14 +26,9 @@ sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root;
   chdir $root or die "can't chdir to $root: $!";
 
-  unless (-e 'Makefile') {
-    die "Can't build without a Makefile. Do you need to cyd configure?\n";
-  }
-
   my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
 
-  run(qw( make lex-fix                  ), @jobs);
-  run(qw( make                          ), @jobs);
+  run(qw( make check ), @jobs);
 }
 
 1;

--- a/Debian/bin/lib/Cyrus/Docker/Command/configure.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/configure.pm
@@ -1,0 +1,147 @@
+use v5.36.0;
+
+package Cyrus::Docker::Command::configure;
+use Cyrus::Docker -command;
+
+use Process::Status;
+use Term::ANSIColor qw(colored);
+
+my sub run (@args) {
+  say "running: @args";
+  system(@args);
+  Process::Status->assert_ok($args[0]);
+}
+
+sub abstract { 'configure cyrus-imapd' }
+
+sub opt_spec {
+  return (
+    [ 'with-sphinx|s', 'enable sphinx docs' ],
+    [ 'sanitizer' => hidden => { one_of => [
+      [ 'asan'  => 'build with AddressSanitizer' ],
+      [ 'ubsan' => 'build with UBSan' ],
+      [ 'ubsan-trap' => 'build with UBSan and trap on error' ],
+    ] } ],
+    [ 'compiler' => hidden => { one_of => [
+      [ 'gcc' => 'gcc', ],
+      [ 'clang' => 'clang', ],
+    ] } ],
+    [ 'cflags=s' => 'additional flags to include in CFLAGS' ],
+    [ 'cxxflags=s' => 'additional flags to include in CXXFLAGS' ],
+  );
+}
+
+sub execute ($self, $opt, $args) {
+  my $root = $self->app->repo_root;
+  chdir $root or die "can't chdir to $root: $!";
+
+  my $version = `./tools/git-version.sh`;
+  Process::Status->assert_ok("determining git version");
+
+  chomp $version;
+
+  if ($version eq 'unknown') {
+    die "git-version.sh can't decide what version this is; giving up!\n";
+  }
+
+  my $with_sanitizer = $opt->sanitizer ? " with " . $opt->sanitizer : "";
+
+  my $san_flags = q{};
+
+  if ($opt->sanitizer) {
+    if ($opt->sanitizer eq 'asan') {
+      $san_flags = '-fsanitize=address';
+
+      my $lsan_opts = $ENV{LSAN_OPTIONS} || "";
+      my $dont_suppress;
+
+      if ($lsan_opts) {
+        my %opts = map { split '=', $_ } split(':', $lsan_opts);
+        if ($opts{supressions} && $opts{supressions} ne "cunit/leaksanitizer.suppress") {
+          warn "Warning! LSAN_OPTIONS already defines a suppressions file so ours will not be used. You may see spurious failures...\n";
+          $dont_suppress = 1;
+        }
+      }
+
+      unless ($dont_suppress) {
+        $ENV{LSAN_OPTIONS} = "$lsan_opts:suppressions=leaksanitizer.suppress";
+      }
+
+      if (! $opt->compiler) {
+        warn colored(['red'], "If using gcc you may need ASAN_OPTIONS=verify_asan_link_order=0 when running cassandane tests.") . "\n";
+        warn colored(['red'], "Alternatively, use 'cyd build --asan --gcc' and I'll configure the build appropriately") . "\n";
+
+      } elsif ($opt->compiler eq 'gcc') {
+        # As of at least gcc 12 we need to statically link libasan or cass
+        # tests fail with "ASan runtime does not come first..." errors
+        $san_flags .= ' -static-libasan';
+      }
+
+    } elsif ($opt->sanitizer =~ /\Aubsan(_trap)?\z/) {
+      $san_flags = '-fsanitize=undefined';
+
+      $ENV{UBSAN_OPTIONS} = "print_stacktrace=1:halt_on_error=1";
+
+      if ($opt->sanitizer eq 'ubsan_trap') {
+        $san_flags .= ' -fsanitize-undefined-trap-on-error';
+      }
+    } else {
+      die "Unknown sanitizer mode '" . $opt->sanitizer . "'?!\n";
+    }
+  }
+
+  my $with_cc = "";
+
+  if ($opt->compiler) {
+    $ENV{CC} = $opt->compiler;
+
+    $with_cc = " using $ENV{CC}";
+  }
+
+  say "building cyrusversion $version$with_cc$with_sanitizer";
+
+  my @configopts = qw(
+    --enable-autocreate
+    --enable-backup
+    --enable-calalarmd
+    --enable-gssapi
+    --enable-http
+    --enable-idled
+    --enable-murder
+    --enable-nntp
+    --enable-replication
+    --enable-shared
+    --enable-silent-rules
+    --enable-debug-slowio
+    --enable-unit-tests
+    --enable-xapian
+    --enable-jmap
+    --with-ldap=/usr
+    --with-nghttp2
+  );
+
+  push @configopts, '--with-sphinx-build=no' unless $opt->with_sphinx;
+
+  my $libsdir = '/usr/local/cyruslibs';
+  my $target  = '/usr/cyrus';
+
+  my $more_cflags = $opt->cflags // "";
+  my $more_cxxflags = $opt->cxxflags // "";
+
+  local $ENV{LDFLAGS} = "-L$libsdir/lib/x86_64-linux-gnu -L$libsdir/lib -Wl,-rpath,$libsdir/lib/x86_64-linux-gnu -Wl,-rpath,$libsdir/lib";
+  local $ENV{PKG_CONFIG_PATH} = "$libsdir/lib/x86_64-linux-gnu/pkgconfig:$libsdir/lib/pkgconfig:\$PKG_CONFIG_PATH";
+  local $ENV{CFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings -Wformat=2 $more_cflags";
+  local $ENV{CXXFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror $more_cxxflags";
+  local $ENV{PATH} = "$libsdir/bin:$ENV{PATH}";
+
+  run(qw( autoreconf -v -i ));
+
+  run(
+    './configure',
+    "--prefix=$target",
+    @configopts,
+    "XAPIAN_CONFIG=$libsdir/bin/xapian-config-1.5",
+  );
+}
+
+1;

--- a/Debian/bin/lib/Cyrus/Docker/Command/install.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/install.pm
@@ -1,6 +1,6 @@
 use v5.36.0;
 
-package Cyrus::Docker::Command::build;
+package Cyrus::Docker::Command::install;
 use Cyrus::Docker -command;
 
 use Process::Status;
@@ -12,11 +12,11 @@ my sub run (@args) {
   Process::Status->assert_ok($args[0]);
 }
 
-sub abstract { 'build a configured cyrus-imapd' }
+sub abstract { 'install a built cyrus-imapd' }
 
 sub opt_spec {
   return (
-    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
+    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make',
                      { default => 8 },
     ],
   );
@@ -26,14 +26,13 @@ sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root;
   chdir $root or die "can't chdir to $root: $!";
 
-  unless (-e 'Makefile') {
-    die "Can't build without a Makefile. Do you need to cyd configure?\n";
-  }
-
   my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
 
-  run(qw( make lex-fix                  ), @jobs);
-  run(qw( make                          ), @jobs);
+  run(qw( sudo make install             ), @jobs);
+  run(qw( sudo make install-binsymlinks ), @jobs);
+  run(qw( sudo cp tools/mkimap /usr/cyrus/bin/mkimap ));
+
+  system('/usr/cyrus/bin/cyr_info', 'version');
 }
 
 1;

--- a/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
@@ -25,7 +25,7 @@ sub opt_spec {
       [ 'gcc' => 'gcc', ],
       [ 'clang' => 'clang', ],
     ] } ],
-    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
+    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make',
                      { default => 8 },
     ],
   );

--- a/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
@@ -1,0 +1,58 @@
+use v5.36.0;
+
+package Cyrus::Docker::Command::prep;
+use Cyrus::Docker -command;
+
+use Process::Status;
+use Term::ANSIColor qw(colored);
+
+my sub run (@args) {
+  say "running: @args";
+  system(@args);
+  Process::Status->assert_ok($args[0]);
+}
+
+sub abstract { 'build a configured cyrus-imapd' }
+
+sub opt_spec {
+  return (
+    [ 'sanitizer' => hidden => { one_of => [
+      [ 'asan'  => 'build with AddressSanitizer' ],
+      [ 'ubsan' => 'build with UBSan' ],
+      [ 'ubsan-trap' => 'build with UBSan and trap on error' ],
+    ] } ],
+    [ 'compiler' => hidden => { one_of => [
+      [ 'gcc' => 'gcc', ],
+      [ 'clang' => 'clang', ],
+    ] } ],
+    [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
+                     { default => 8 },
+    ],
+  );
+}
+
+sub execute ($self, $opt, $args) {
+  my $root = $self->app->repo_root;
+  chdir $root or die "can't chdir to $root: $!";
+
+  my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
+
+  my @sanitizer = $opt->sanitizer ? ('--' . $opt->sanitizer) : ();
+  my @compiler  = $opt->compiler  ? ('--' . $opt->compiler ) : ();
+
+  my @to_run = (
+    [ 'Cyrus::Docker::Command::configure', (@sanitizer, @compiler) ],
+    [ 'Cyrus::Docker::Command::build',   (@jobs) ],
+    [ 'Cyrus::Docker::Command::check',   (@jobs) ],
+    [ 'Cyrus::Docker::Command::install', (@jobs) ],
+  );
+
+  for my $to_run (@to_run) {
+    (my $class, local @ARGV) = @$to_run;
+
+    my ($cmd, $opt, @args) = $class->prepare($self->app);
+    $self->app->execute_command($cmd, $opt, @args);
+  }
+}
+
+1;

--- a/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/prep.pm
@@ -16,6 +16,7 @@ sub abstract { 'build a configured cyrus-imapd' }
 
 sub opt_spec {
   return (
+    [ 'with-sphinx|s', 'enable sphinx docs' ],
     [ 'sanitizer' => hidden => { one_of => [
       [ 'asan'  => 'build with AddressSanitizer' ],
       [ 'ubsan' => 'build with UBSan' ],
@@ -37,11 +38,12 @@ sub execute ($self, $opt, $args) {
 
   my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
 
-  my @sanitizer = $opt->sanitizer ? ('--' . $opt->sanitizer) : ();
-  my @compiler  = $opt->compiler  ? ('--' . $opt->compiler ) : ();
+  my @sphinx    = $opt->with_sphinx ? ('--with-sphinx')        : ();
+  my @sanitizer = $opt->sanitizer   ? ('--' . $opt->sanitizer) : ();
+  my @compiler  = $opt->compiler    ? ('--' . $opt->compiler ) : ();
 
   my @to_run = (
-    [ 'Cyrus::Docker::Command::configure', (@sanitizer, @compiler) ],
+    [ 'Cyrus::Docker::Command::configure', (@sphinx, @sanitizer, @compiler) ],
     [ 'Cyrus::Docker::Command::build',   (@jobs) ],
     [ 'Cyrus::Docker::Command::check',   (@jobs) ],
     [ 'Cyrus::Docker::Command::install', (@jobs) ],

--- a/Debian/bin/lib/Cyrus/Docker/Command/shell.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/shell.pm
@@ -20,9 +20,9 @@ sub do_motd {
           /////    |||| Run cyrus-docker (or "cyd") as:
         /////      ||||
       /////        ||||  • cyd clone  - clone cyrus-imapd.git from GitHub
-    /////          ||||  • cyd build  - build your checked out cyrus-imapd
+    /////          ||||  • cyd prep   - configure, build, check, and install
     \\\\\          ||||  • cyd test   - run the cyrus-imapd test suite
-      \\\\\        ||||  • cyd smoke  - check out, build and test
+      \\\\\        ||||  • cyd smoke  - clone, prep, and test
         \\\\\      ||||
           \\\\\    ||||  • cyd shell  - run a shell in the container
             \\\\\  ||||

--- a/Debian/bin/lib/Cyrus/Docker/Command/smoke.pm
+++ b/Debian/bin/lib/Cyrus/Docker/Command/smoke.pm
@@ -11,7 +11,10 @@ sub execute ($self, $opt, $args) {
   my @classes = qw(
     Cyrus::Docker::Command::clone
     Cyrus::Docker::Command::clean
+    Cyrus::Docker::Command::configure
     Cyrus::Docker::Command::build
+    Cyrus::Docker::Command::check
+    Cyrus::Docker::Command::install
     Cyrus::Docker::Command::test
   );
 


### PR DESCRIPTION
This branch splits "cyd build" up into its constituent parts, then adds "cyd prep" which combines them.

So, now "cyd install" will just do a "make install", generally meaning that using it over and over to do a minimal compile and install will be efficient.  "cyd prep" will do a full configure and build and install, for those who want it.

There's a matching change for cyrus-imapd.git, which will update the GitHub Actions CI.