### PR TITLE
Revert "Dockerfile: install libclamav-dev"

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -19,7 +19,6 @@ apt-get -y install --no-install-recommends \
     bison \
     build-essential \
     check \
-    clamav-freshclam \
     clang \
     cmake \
     comerr-dev \
@@ -39,7 +38,6 @@ apt-get -y install --no-install-recommends \
     libanyevent-perl \
     libbsd-dev \
     libbsd-resource-perl \
-    libclamav-dev \
     libclang-rt-dev \
     libcld2-dev \
     libclone-perl \


### PR DESCRIPTION
Reverts cyrusimap/cyrus-docker#52

ClamAV.remove_infected_slow is failing in CI.  This is what clamav-freshclam was supposed to fix, not sure why it didn't, but let's unbreak CI until we figure it out...