### PR TITLE
Debian/Dockerfile: Pin Text::JSCalendar to 0.03 for now

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -202,6 +202,7 @@ $CPANM \
   IO::File::fcntl \
   JMAP::Tester~0.109 \
   Mail::IMAPTalk \
+  Text::JSCalendar@0.03 \
   Net::CalDAVTalk~0.14 \
   Net::CardDAVTalk~0.11 \
   Process::Status \


### PR DESCRIPTION
>= 0.04 have changes that are not compatible with cassandane at the
moment.