### PR TITLE
Dockerfile: unpin Text::JSCalendar

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -202,7 +202,6 @@ $CPANM \
   IO::File::fcntl \
   JMAP::Tester~0.109 \
   Mail::IMAPTalk \
-  Text::JSCalendar@0.03 \
   Net::CalDAVTalk~0.14 \
   Net::CardDAVTalk~0.11 \
   Process::Status \


### PR DESCRIPTION
This effectively reverts 3080fa8

Instead of this, which has become unworkable due to version conflicts, we now install the latest versions of Net::CalDAVTalk and Net::CardDAVTalk from CPAN and then shadow them directly inside cyrus-imapd.  This is not a good long term solution, but lets us get CI builds working internally again.