### PR TITLE
documentation: put more information in here about how it all works

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -187,6 +187,7 @@ apt-get -y install --no-install-recommends \
     valgrind \
     `# BEGIN for cyrus-docker or just quality of life` \
     less \
+    libfile-pushd-perl \
     tini
 EOF
 

--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -1,13 +1,47 @@
+# =============================================================================
+# Cyrus IMAP development image (Debian)
+#
+# This Dockerfile builds "cyrus-docker", the image the Cyrus team uses for CI
+# and for local development.  It is also meant to be *read*: the Cyrus developer
+# documentation points here instead of maintaining a second list of build and
+# test dependencies
+#
+# So, if you are setting up to build Cyrus somewhere other than this image --
+# another distro, or bare metal -- this file is the authoritative answer to
+# "what do I need?".  It's Debian-based, so you'll have to translate package
+# names to your own system, but nothing required should be hidden elsewhere.
+#
+# The build proceeds in stages:
+#
+#   1. install Debian packages: the C build toolchain, the libraries Cyrus
+#      links against, and the Perl modules Cassandane needs
+#   2. create the "cyrus" user/group and minimal system config
+#   3. fetch and build the external test tools we pin to known-good commits
+#      (CalDAVTester, Dovecot, imaptest, JMAP-TestSuite)
+#   4. build cyruslibs: libraries at versions newer than Debian ships
+#   5. install "cyd", the in-container tooling, under /srv/bin
+#
+# Note that the build/test/coverage *steps* themselves live in cyd, not here.
+# If you want to know exactly how Cyrus is configured, built, and tested, then
+# read lib/Cyrus/Docker/Command/*.pm -- e.g. the reference ./configure
+# invocation lives in Command/build.pm.
+# =============================================================================
+
 # If you change the default source image, update the README, which references
 # the underlying Debian version.
 ARG DEBIAN_VERSION=bookworm
 FROM debian:$DEBIAN_VERSION
 LABEL org.opencontainers.image.authors="Cyrus IMAP <docker@role.fastmailteam.com>"
-
 LABEL org.cyrusimap.cyrus-docker.version="1.0"
 
 RUN <<EOF
 # install prerequisites via apt-get
+#
+# This list is deliberately a superset.  The unlabelled packages below are the
+# C build toolchain, the libraries Cyrus links against, and the core Perl
+# modules Cassandane needs to run.  The `# BEGIN ...` markers further down group
+# packages added for specific purposes (extra Cassandane/Cyrus prereqs, the
+# JMAP test suite, building the docs, and quality-of-life tools).
 set -e
 apt-get update
 apt-get -y install build-essential
@@ -158,12 +192,14 @@ EOF
 
 RUN <<EOF
 # set up users, groups, and config
+#
+# Cyrus expects to runs as the unprivileged "cyrus" user.  The important things
+# are that it run as a non-root user in the groups "mail" and in "saslauth".
 set -e
 groupadd -r saslauth
 
 # The "mail" group exists on stock Debian, we don't need to add it here.
 # groupadd -r mail
-
 useradd -c "Cyrus IMAP Server" -d /var/lib/imap -g mail -G saslauth -s /bin/bash -r cyrus
 
 git config --global http.sslverify false
@@ -178,6 +214,10 @@ WORKDIR /srv
 
 RUN <<EOF
 # clone CalDAVTester
+#
+# This isn't needed to run Cyrus, it's a Cyrus's fork of the (possibly
+# abandoned?) Apple Calendar and Contacts Server's CAlDAVTester test suite.
+# We'll test Cyrus builds against this.
 git clone --depth 1 --shallow-submodules https://github.com/cyrusimap/CalDAVTester.git
 EOF
 
@@ -192,6 +232,9 @@ ARG CLEANUP=true
 
 RUN <<EOF
 # install Perl prerequisites from CPAN
+#
+# This is generally stuff not found in Debian, or where we need a newer
+# version.
 set -e
 $CPANM \
   App::Cmd \
@@ -213,6 +256,8 @@ EOF
 
 RUN <<EOF
 # clone and prep JMAP Test Suite
+#
+# Again, just needed so we can run the tests.
 set -e
 git clone --depth 1 --shallow-submodules https://github.com/fastmail/JMAP-TestSuite.git
 cd JMAP-TestSuite
@@ -222,6 +267,9 @@ EOF
 
 RUN <<EOF
 # install Mail::JMAPTalk
+#
+# Another Perl prereq, but this one so new that we expect to need the version
+# right from the repo, rather than the latest CPAN release.
 set -e
 git clone --depth 1 --shallow-submodules https://github.com/cyrusimap/Mail-JMAPTalk.git
 cd Mail-JMAPTalk
@@ -241,7 +289,11 @@ ARG IMAPTEST_COMMIT=0c24edb324f10a08223097b5cda145fa005c4026
 
 RUN <<EOF
 # clone and build dovecot.git
-# This one is weird.  We want a specific commit, just for the sake of pinning
+#
+# This is because we want Dovecot's "imaptest" program for doing testing of our
+# IMAP implementation, and it wants Dovecot.
+#
+# This step is weird.  We want a specific commit, just for the sake of pinning
 # to known-good.  We install so that imaptest (below) can rely on the installed
 # Dovecot even after we remove the source.  We remove the source because it's a
 # whole lot of bytes that we don't really need to ship in the OCI image.
@@ -281,11 +333,15 @@ ARG CYRUSLIBS_BRANCH=master
 
 RUN <<EOF
 # clone and build cyruslibs
+#
+# cyruslibs bundles libraries -- most importantly for Xapian search -- at
+# versions newer than Debian ships.  Cyrus builds against these, installed
+# under /usr/local/cyruslibs.  This is why `cyd build` points configure's
+# CFLAGS/LDFLAGS/PKG_CONFIG_PATH and XAPIAN_CONFIG at that prefix.
 set -e
 git clone --depth 1 --shallow-submodules -b $CYRUSLIBS_BRANCH \
   https://github.com/cyrusimap/cyruslibs.git
 cd cyruslibs
-# RUN git checkout origin/master
 ./build.sh
 cd ..
 $CLEANUP && rm -rf cyruslibs || true

--- a/Debian/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/lib/Cyrus/Docker/Command/build.pm
@@ -14,6 +14,24 @@ my sub run (@args) {
 
 sub abstract { 'configure, build, and install cyrus-imapd' }
 
+sub description {
+  return <<~'END';
+  Configure, build, "make check", and install cyrus-imapd from the checkout at
+  /srv/cyrus-imapd (or wherever CYRUS_CLONE_ROOT points).
+
+  This is the canonical way Cyrus is built for development and CI.  The set of
+  ./configure options used here is the *reference build configuration*: if you
+  ever need to build Cyrus by hand, the list in the configure() method below is
+  the one to copy.
+
+  Common combinations:
+    build         configure, build, run the fast CUnit checks, and install
+    build -r      recompile a previous build (skip configure)
+    build -n      skip the "make check" step
+    build -nr     recompile, skipping both configure and "make check"
+  END
+}
+
 # gcov isn't strictly a sanitizer, but it's easier to implement it as one
 # (and it doesn't make sense to run coverage on a sanitizer build, even if the
 # compiler would let us)
@@ -85,6 +103,14 @@ sub configure ($self, $opt) {
     die "git-version.sh can't decide what version this is; giving up!\n";
   }
 
+  # This is the reference ./configure invocation: the full set of features we
+  # build and test in CI.  Build Cyrus by hand and this is the list to copy.  A
+  # few that aren't self-explanatory:
+  #
+  #   --enable-unit-tests  builds the CUnit suite ("make check")
+  #   --enable-xapian      search; needs the newer libs from cyruslibs (above)
+  #   --enable-debug-slowio deliberately slows some I/O to surface ordering bugs
+  #   --enable-jmap / --enable-http  the httpd subsystem (JMAP, *DAV)
   my @configopts = qw(
     --enable-autocreate
     --enable-calalarmd

--- a/Debian/lib/Cyrus/Docker/Command/clean.pm
+++ b/Debian/lib/Cyrus/Docker/Command/clean.pm
@@ -7,6 +7,15 @@ use Process::Status;
 
 sub abstract { 'clean all build artifacts in the cyrus-imapd source tree' }
 
+sub description {
+  return <<~'END';
+  Remove build artifacts from the checkout with "git clean".  This only deletes
+  git-ignored files (the -X flag), so new source files you haven't yet added are
+  safe; it will not blow away uncommitted work the way a plain "git clean -dfx"
+  would.
+  END
+}
+
 sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root;
   chdir $root or die "can't chdir to $root: $!";

--- a/Debian/lib/Cyrus/Docker/Command/clone.pm
+++ b/Debian/lib/Cyrus/Docker/Command/clone.pm
@@ -8,6 +8,16 @@ use Process::Status;
 
 sub abstract { 'clone the cyrus-imapd source tree to /srv, if not present' }
 
+sub description {
+  return <<~'END';
+  Clone cyrus-imapd.git to the repo root (default /srv/cyrus-imapd) if nothing
+  is there yet.  If the directory already exists, this does nothing -- it will
+  not touch or update an existing checkout.  For day to day development, you'll
+  probably work with a checkout mounted from the host (via dar) rather than one
+  cloned here.
+  END
+}
+
 sub execute ($self, $opt, $arg) {
   my $root = $self->app->repo_root;
   my $repo = 'https://github.com/cyrusimap/cyrus-imapd.git';

--- a/Debian/lib/Cyrus/Docker/Command/coverage.pm
+++ b/Debian/lib/Cyrus/Docker/Command/coverage.pm
@@ -8,6 +8,13 @@ use Cwd;
 
 sub abstract { 'generate code coverage for the cyrus-imapd repo' }
 
+sub description {
+  return <<~'END';
+  Build Cyrus with coverage instrumentation, run both test suites, and produce a
+  combined HTML coverage report under ./coverage.
+  END
+}
+
 my sub run (@args) {
   system(@args);
   Process::Status->assert_ok($args[0]);

--- a/Debian/lib/Cyrus/Docker/Command/distcheck.pm
+++ b/Debian/lib/Cyrus/Docker/Command/distcheck.pm
@@ -16,6 +16,20 @@ my sub run (@args) {
 
 sub abstract { 'do a distcheck against cyrus-imapd' }
 
+sub description {
+  return <<~'END';
+  Build a release tarball with "make distcheck", then unpack it somewhere clean
+  and build and test *that* with cyd build / cyd test.  This is how we confirm
+  the dist tarball is self-contained and that a from-tarball build (the path a
+  packager or end user takes) actually works.
+
+  By default it insists the checkout be clean; pass --dirty to distcheck a dirty
+  tree on purpose (and it will then insist the tree *is* dirty, to catch
+  mistakes).  Use --brief to stop after "make distcheck" without testing the
+  unpacked tarball.
+  END
+}
+
 sub opt_spec {
   return (
     [ 'jobs|j=i', 'specify number of parallel jobs (default: 8) to run for make',
@@ -70,7 +84,12 @@ sub execute ($self, $opt, $args) {
   my ($tarball) = glob("cyrus-imapd-*-g${commit}*${dirty}.tar.gz");
 
   unless ($tarball) {
-    die "Can't find the tarball we should've just built!\n";
+    die <<~'END'
+    Can't find the tarball we should've just built!  This often means that you
+    had a stale configure result, and built for the configured version, not the
+    version that tools/git-version.sh would now produce.
+
+    END
   }
 
   my $full_tarball_path = File::Spec->catfile($root, $tarball);

--- a/Debian/lib/Cyrus/Docker/Command/makedocs.pm
+++ b/Debian/lib/Cyrus/Docker/Command/makedocs.pm
@@ -7,6 +7,15 @@ use Process::Status;
 
 sub abstract { 'make the docs tree using Sphinx' }
 
+sub description {
+  return <<~'END';
+  Build the cyrus-imapd documentation site (docsrc/) with Sphinx, writing HTML
+  to docsrc/build/html.  This is the right way to preview documentation changes
+  locally.  The build runs nitpicky and warnings-as-errors (-n -W), so a doc
+  change that builds clean here will build clean in CI.
+  END
+}
+
 sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root->child('docsrc');
   chdir $root or die "can't chdir to $root: $!";

--- a/Debian/lib/Cyrus/Docker/Command/makedocs.pm
+++ b/Debian/lib/Cyrus/Docker/Command/makedocs.pm
@@ -17,8 +17,26 @@ sub description {
 }
 
 sub execute ($self, $opt, $args) {
-  my $root = $self->app->repo_root->child('docsrc');
+  my $root = $self->app->repo_root;
   chdir $root or die "can't chdir to $root: $!";
+
+  require Path::Tiny;
+  my $status = Path::Tiny::path("config.status");
+  my $have_sphinx;
+  LINE: for my $line ($status->exists ? $status->lines : ()) {
+    if ($line =~ m{^S\["SPHINX_BUILD"\]="[^"]+"$}m) {
+      $have_sphinx = 1;
+      last LINE;
+    }
+  }
+
+  if ($have_sphinx) {
+    say "already configured with sphinx, great!";
+  } else {
+    my $class = 'Cyrus::Docker::Command::build';
+    my ($cmd, $opt, @args) = $class->prepare($self->app, qw(--with-sphinx -n));
+    $self->app->execute_command($cmd, $opt, @args);
+  }
 
   # I would prefer to use long form options, but they are not added until
   # Sphinx v7, and we are using v5 right now. -- rjbs, 2025-01-10
@@ -26,8 +44,9 @@ sub execute ($self, $opt, $args) {
   #
   # -n is "--nitpicky"
   # -W is "--fail-on-warning"
-  system('make', q{SPHINXOPTS=-n -W}, 'html');
-  Process::Status->assert_ok('making "html" target');
+  local $ENV{SPHINXOPTS} = q{SPHINXOPTS=-n -W};
+  system('make doc');
+  Process::Status->assert_ok('making "doc" target');
 }
 
 1;

--- a/Debian/lib/Cyrus/Docker/Command/makesite.pm
+++ b/Debian/lib/Cyrus/Docker/Command/makesite.pm
@@ -3,6 +3,7 @@ use v5.36.0;
 package Cyrus::Docker::Command::makesite;
 use Cyrus::Docker -command;
 
+use File::pushd;
 use Process::Status;
 use Path::Tiny;
 
@@ -44,6 +45,17 @@ my sub cyrus_branch ($branch, $paths = undef) {
   );
 }
 
+my sub cyrus_branch_legacy ($branch, $paths = undef) {
+  return (
+    $branch => {
+      repo   => 'imapd',
+      branch => $branch,
+      paths  => $paths // [ "/" . ($branch =~ s{^cyrus-imapd-}{}r) ],
+      make_docsrc => 1, # use "make -C docsrc" to avoid configure
+    },
+  );
+}
+
 sub execute ($self, $opt, $args) {
   # A semi-persistent working directory
   # (unclear if we still need this. It was intended in the original to reduce
@@ -65,6 +77,7 @@ sub execute ($self, $opt, $args) {
       repo    => 'sasl',
       branch  => 'master',
       paths   => [ '/sasl' ],
+      make_docsrc => 1,
     },
 
     cyrus_branch('master', [ '/dev' ]),
@@ -75,9 +88,9 @@ sub execute ($self, $opt, $args) {
     archive_copy('3.4'),
     archive_copy('3.6'),
 
-    cyrus_branch('cyrus-imapd-3.8'),
-    cyrus_branch('cyrus-imapd-3.10'),
-    cyrus_branch('cyrus-imapd-3.12', [ '/3.12', '/', '/stable' ]),
+    cyrus_branch_legacy('cyrus-imapd-3.8'),
+    cyrus_branch_legacy('cyrus-imapd-3.10'),
+    cyrus_branch_legacy('cyrus-imapd-3.12', [ '/3.12', '/', '/stable' ]),
   );
 
   # set up our basedir
@@ -94,7 +107,7 @@ sub execute ($self, $opt, $args) {
 
   # build the docs from each source
   my %current;
-  foreach my $source_name (sort keys %source) {
+  for my $source_name (sort keys %source) {
     say "::group::building $source_name section of site"; # GitHub Actions log
 
     my $details = $source{$source_name};
@@ -112,8 +125,16 @@ sub execute ($self, $opt, $args) {
       run_or_die('git', 'clone', $repo_url,
                  '--branch', $branch,
                  '--single-branch',
-                 '--no-tags',
-                 '--depth', 1,
+
+                 # We used to build "--no-tags --depth 1" but we can't do that
+                 # if we want to "make doc" because we need to configure first.
+                 #
+                 # We can probably speed this all up by making a clone or
+                 # worktree from the single pre-existing checkout.  Future
+                 # work.  CYR-3197 -- rjbs, 2026-07-07
+                 # '--no-tags',
+                 # '--depth', 1
+
                  # We can add this unconditionally. git doesn't really care if
                  # we're cloning cyrus-sasl with cyrus-imapd as our reference
                  '--reference', $self->app->repo_root,
@@ -131,9 +152,16 @@ sub execute ($self, $opt, $args) {
     } else {
       say "#### building docs for $source_name...";
       run_or_die('git', '-C', $dir, 'checkout', '-q', "origin/$branch");
-      run_or_die('make', '-C', $dir->child('docsrc'), 'html');
 
-      $src = $basedir->child($source_name, qw(docsrc build html));
+      if ($details->{make_docsrc}) {
+        run_or_die('make', '-C', $dir->child('docsrc'), 'html');
+        $src = $basedir->child($source_name, qw(docsrc build html));
+      } else {
+        local $ENV{CYRUS_CLONE_ROOT} = "$dir";
+        my $guard = pushd("$dir");
+        run_or_die('/srv/bin/cyd', 'makedocs');
+        $src = $basedir->child($source_name, qw(doc html));
+      }
     }
 
     for my $path ($details->{paths}->@*) {

--- a/Debian/lib/Cyrus/Docker/Command/makesite.pm
+++ b/Debian/lib/Cyrus/Docker/Command/makesite.pm
@@ -58,7 +58,7 @@ sub execute ($self, $opt, $args) {
     sasl    => 'https://github.com/cyrusimap/cyrus-sasl.git',
     imapd   => 'https://github.com/cyrusimap/cyrus-imapd.git',
     archive => 'https://github.com/cyrusimap/cyrusimap.github.io.git',
-);
+  );
 
   my %source = (
     'cyrus-sasl' => {
@@ -79,7 +79,6 @@ sub execute ($self, $opt, $args) {
     cyrus_branch('cyrus-imapd-3.10'),
     cyrus_branch('cyrus-imapd-3.12', [ '/3.12', '/', '/stable' ]),
   );
-
 
   # set up our basedir
   $basedir->mkdir unless $basedir->is_dir;

--- a/Debian/lib/Cyrus/Docker/Command/smoke.pm
+++ b/Debian/lib/Cyrus/Docker/Command/smoke.pm
@@ -7,6 +7,14 @@ use Process::Status;
 
 sub abstract { 'build and test the contents of cyrus-imapd repo' }
 
+sub description {
+  return <<~'END';
+  The all-in-one shortcut: clone (if needed), clean, build, and test.  CI runs
+  effectively this: cyd build, then cyd test.  smoke is a good single command
+  to confirm a checkout is healthy.
+  END
+}
+
 sub execute ($self, $opt, $args) {
   my @classes = qw(
     Cyrus::Docker::Command::clone

--- a/Debian/lib/Cyrus/Docker/Command/test.pm
+++ b/Debian/lib/Cyrus/Docker/Command/test.pm
@@ -8,6 +8,20 @@ use Process::Status;
 
 sub abstract { 'test the cyrus-imapd repo with cassandane' }
 
+sub description {
+  return <<~'END';
+  Run the Cassandane (Perl integration) test suite against the built Cyrus.
+
+  With no arguments, runs every test.  Otherwise, name suites or individual
+  tests as documented in testrunner.pl:
+
+    test Quota                run the whole Quota suite
+    test Quota.quotarename    run one test
+    test Admin Quota          run several
+    test ~Quota               run everything *except* the Quota suite
+  END
+}
+
 sub opt_spec {
   return (
     [ 'format=s', "which formatter to use; default: pretty",
@@ -32,6 +46,8 @@ sub execute ($self, $opt, $args) {
   my $root = $self->app->repo_root->child('cassandane');
   chdir $root or die "can't chdir to $root: $!";
 
+  # Cassandane needs a cassandane.ini.  In the image we just drop the canonical
+  # "dockertests" profile into place and hand it to the cyrus user.
   unless (-e "cassandane.ini") {
     system(qw(cp -af cassandane.ini.dockertests cassandane.ini));
     Process::Status->assert_ok('copying cassandane.ini.dockertests to cassandane.ini');
@@ -89,6 +105,9 @@ sub execute ($self, $opt, $args) {
     Process::Status->assert_ok('Cassandane make syntax');
   }
 
+  # Cassandane (really, the Cyrus code it drives) must run as the "cyrus" user,
+  # not root.  We drop to cyrus:mail with setpriv.  Note there's no sudo here:
+  # running inside the container we're already root and simply step *down*.
   system(
     qw( setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps=-all ),
     qw( ./testrunner.pl ), @jobs, qw( -f ), $opt->format,


### PR DESCRIPTION
This is a bit of a prelude to removing a lot of outdated and unhelpful documentation from cyrusimap.org, and instead replacing it with a pointer saying "to see how we actually build Cyrus testing, and its reference configuration, see cyrus-docker."