### PR TITLE
cyd build: Add --with-sasl which is passed through to ./configure

### DIFF
--- a/Debian/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/lib/Cyrus/Docker/Command/build.pm
@@ -22,6 +22,7 @@ sub opt_spec {
   return (
     [ 'recompile|r', 'recompile, make check, and install a previous build' ],
     [ 'with-sphinx|s', 'enable sphinx docs' ],
+    [ 'with-sasl=s', 'build with SASL from this directory' ],
     [ 'jobs|j=i',    'specify number of parallel jobs (default: 8) to run for make/make check',
                      { default => 8 },
     ],
@@ -105,6 +106,8 @@ sub configure ($self, $opt) {
   );
 
   push @configopts, '--with-sphinx-build=no' unless $opt->with_sphinx;
+
+  push @configopts, '--with-sasl=' . $opt->with_sasl if defined $opt->with_sasl;
 
   my $with_sanitizer = $opt->sanitizer ? " with " . $opt->sanitizer : "";
 


### PR DESCRIPTION
This makes it easier to build Cyrus against a locally installed SASL.