### PR TITLE
Dockerfile: install libauthen-scram-perl

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -38,6 +38,7 @@ apt-get -y install --no-install-recommends \
     heimdal-dev \
     help2man \
     libanyevent-perl \
+    libauthen-scram-perl \
     libbsd-dev \
     libbsd-resource-perl \
     libclamav-dev \


### PR DESCRIPTION
Authen::SCRAM lets us test the SCRAM authentication code paths. The debian package is current.