### PR TITLE
cyd distcheck: also check the docs

### DIFF
--- a/Debian/lib/Cyrus/Docker/Command/distcheck.pm
+++ b/Debian/lib/Cyrus/Docker/Command/distcheck.pm
@@ -111,6 +111,8 @@ sub execute ($self, $opt, $args) {
 
   run(qw( cyd test ));
 
+  run(qw( cyd makedocs ));
+
   # chdir back to original root so that tempdir can be cleaned up
   chdir $root or die "can't chdir to $root: $!";
 }


### PR DESCRIPTION
Adding "cyd makedocs" will run a strict sphinx-build, so we can find out about broken docs.  This isn't run from the CI, which only does "cyd distcheck --brief", because it *already* does a separate make docs check.  But it will be run by a human running "dar distcheck", which means we can strip down the release instructions a bit more."