### PR TITLE
cyd build --ubsan: gcc adds -lubsan automatically. clang doesn't

### DIFF
--- a/Debian/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/lib/Cyrus/Docker/Command/build.pm
@@ -138,6 +138,7 @@ sub configure ($self, $opt) {
   my $with_sanitizer = $opt->sanitizer ? " with " . $opt->sanitizer : "";
 
   my $san_flags = q{};
+  my $san_ldflags = q{};
 
   if ($opt->sanitizer) {
     $san_flags = '-fno-omit-frame-pointer';
@@ -178,6 +179,18 @@ sub configure ($self, $opt) {
       if ($opt->sanitizer eq 'ubsan_trap') {
         $san_flags .= ' -fsanitize-undefined-trap-on-error';
       }
+
+      if (! $opt->compiler) {
+        # As gcc is our default compiler, and no special flags are needed, a
+        # warning here feels like just noise (contrast with the asan case above)
+      } elsif ($opt->compiler eq 'clang') {
+        # https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
+        #    When the -fsanitize=undefined option is used to link a program,
+        #    the GCC driver automatically links against libubsan.
+        # clang offers no such luxury, and hence libcyrus.so and libcyrus_min.so
+        # have unresolved references to __ubsan_handle_type_mismatch_v1
+        $san_ldflags .= ' -lubsan';
+      }
     } elsif ($opt->sanitizer eq 'cover') {
       # lcov was fine without this, but gcovr needs it
       # Leaving it in, as other alternative tools we trial might want it too:
@@ -211,7 +224,7 @@ sub configure ($self, $opt) {
   my $more_cflags = $opt->cflags // "";
   my $more_cxxflags = $opt->cxxflags // "";
 
-  local $ENV{LDFLAGS} = "-L$libsdir/lib/x86_64-linux-gnu -L$libsdir/lib -Wl,-rpath,$libsdir/lib/x86_64-linux-gnu -Wl,-rpath,$libsdir/lib";
+  local $ENV{LDFLAGS} = "$san_ldflags -L$libsdir/lib/x86_64-linux-gnu -L$libsdir/lib -Wl,-rpath,$libsdir/lib/x86_64-linux-gnu -Wl,-rpath,$libsdir/lib";
   local $ENV{PKG_CONFIG_PATH} = "$libsdir/lib/x86_64-linux-gnu/pkgconfig:$libsdir/lib/pkgconfig:\$PKG_CONFIG_PATH";
   local $ENV{CFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings -Wformat=2 $more_cflags";
   local $ENV{CXXFLAGS} = "$san_flags -g -fPIC -W -Wall -Wextra -Werror $more_cxxflags";


### PR DESCRIPTION
How the compiler implements -fsanitize=undefined is an *implementation* detail. If the code generator needs runtime support, that's its concern.

gcc ensures that when called for linking with -fsanitize=undefined the generated objects have a dependency on libubsan.so, and everything transparently works.

clang forces us to hard code the name of its internal support library. But only for shared objects.

One shouldn't need to diff the output of `ldd` to work this out.