### PR TITLE
Install clang tools and generate compile_commands.json file

### DIFF
--- a/Debian/Dockerfile
+++ b/Debian/Dockerfile
@@ -50,6 +50,7 @@ apt-get -y install --no-install-recommends \
     automake \
     autotools-dev \
     bash-completion \
+    bear \
     bison \
     build-essential \
     check \
@@ -189,6 +190,30 @@ apt-get -y install --no-install-recommends \
     less \
     libfile-pushd-perl \
     tini
+EOF
+
+# Install recent versions of clang tooling, rather than relying on the ones
+# shipped with Debian. Our clang-format config uses directives that aren't
+# supported by current Debian baseline release bookworm.
+ARG LLVM_VERSION=21
+
+RUN <<EOF
+set -e
+apt-get update
+apt-get -y install --no-install-recommends ca-certificates gnupg
+. /etc/os-release
+wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+  | gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${LLVM_VERSION} main" \
+  > /etc/apt/sources.list.d/llvm.list
+apt-get update
+apt-get -y install --no-install-recommends \
+    clang-format-${LLVM_VERSION} \
+    clang-tidy-${LLVM_VERSION} \
+    clangd-${LLVM_VERSION}
+update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} 100
+update-alternatives --install /usr/bin/clang-tidy   clang-tidy   /usr/bin/clang-tidy-${LLVM_VERSION}   100
+update-alternatives --install /usr/bin/clangd       clangd       /usr/bin/clangd-${LLVM_VERSION}       100
 EOF
 
 RUN <<EOF

--- a/Debian/lib/Cyrus/Docker/Command/build.pm
+++ b/Debian/lib/Cyrus/Docker/Command/build.pm
@@ -67,6 +67,7 @@ sub opt_spec {
     ] } ],
     [ 'cflags=s' => 'additional flags to include in CFLAGS' ],
     [ 'cxxflags=s' => 'additional flags to include in CXXFLAGS' ],
+    [ 'bear|b' => 'run make with bear' ],
   );
 }
 
@@ -78,7 +79,9 @@ sub execute ($self, $opt, $args) {
 
   my @jobs = ("-j", $self->app->config->{default_jobs} // $opt->jobs);
 
-  run(qw( make                          ), @jobs);
+  # bear generates compile_commands.json for clang tooling
+  my @with_bear = $opt->bear ? qw(bear --) : ();
+  run(@with_bear, qw(make                  ), @jobs);
 
   if (my $target = $opt->cunit_style) {
     $target =~ s/_/-/;


### PR DESCRIPTION
This changes the Dockerfile to install clang tools such as clangd, clang-format and clang-tidy. Rather than using the clang tools shipped with Debian, it installs and pins them to version 21 (the current latest version). This is to allow using clang-format directives that are not supported in the Debian bookworm baseline installation.

To make use of the clang tools, Cyrus needs to generate the compilation database for clang. The Dockerfile installs the "bear" command and cyd is updated to generate the `compile_commands.json` file.