### PR TITLE
cleanup-images: stop deleting the per-arch halves of our images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,27 +1,27 @@
 name: Clean up old GHCR images
 
 on:
-  workflow_dispatch: {}
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Only report what would be deleted
+        type: boolean
+        default: false
 
 jobs:
   cleanup-old-containers:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Destroy untagged images
-        uses: actions/delete-package-versions@v5
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
-          package-name: 'cyrus-docker'
-          package-type: 'container'
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          package: cyrus-docker
+          keep-n-untagged: 10
+          validate: true
+          # Belt and braces: never touch an image carrying a release tag.
+          exclude-tags: bookworm*,trixie*
+          dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
actions/delete-package-versions isn't discerning enough, it turns out.

We publish multi-arch versions now, which means:

```
  a1111a1111a1111 <- tag points at this
    +-- b222b222  <- no tag, arm64 version
    +-- c333c333  <- no tag, amd64 version
```

"delete untagged versions" could've deleted the second and third of those -- but that's where all the value is!  Keeping the per-arch pointers is pointless when the pointer points to nothing.  Something something null dereference.

We lucked out that we didn't delete any of this stuff because of our other rules.

dataaxiom/ghcr-cleanup-action understands manifest lists and only deletes images nothing references.  keep-n-untagged keeps the ten newest orphaned images as rollback backlog, matching the old intent.  Dispatch defaults to dry-run; run it once that way and read the plan before running it for real.